### PR TITLE
migrate ARAPI to its most recent version

### DIFF
--- a/Dockerfile-basenode
+++ b/Dockerfile-basenode
@@ -18,7 +18,7 @@ ENV CAROOT=/opt
 RUN mkcert -install
 
 # Install npm dependencies
-RUN npm install express
+RUN npm install express@4.18.0
 
 ARG SERVER_LOCATION
 COPY $SERVER_LOCATION/server.js .

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ run:
 	docker compose up
 
 browser:
-	docker exec fledge_lab-client-1 /bin/bash -c 'chrome $${CHROME_ARGS} $${FLEDGE_FLAGS} $${ARAPI_FLAGS}'
+	docker exec fledge_lab-client-1 /bin/bash -c 'chrome $${CHROME_ARGS} $${PRIVACY_SANDBOX_FLAGS}'
 
 vnc:
 ifeq ($(OS),Darwin)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ---
 
-The goal of this project is to provide an easy and friendly way to gain a practical understanding of the [FLEDGE](https://github.com/WICG/turtledove/blob/main/FLEDGE.md) API and its implementation.
+The goal of this project is to provide an easy and friendly way to gain a practical understanding of the [FLEDGE](https://github.com/WICG/turtledove/blob/main/FLEDGE.md) API and its implementation. It also includes other parts of the [Privacy Sandbox](https://privacysandbox.com/) like [ARAPI](https://github.com/WICG/conversion-measurement-api) and may expand in the future.
 
 Feel free to contribute if you have any ideas or ask if you want to use it but don't know how to get started.
 
@@ -180,9 +180,9 @@ python denial_of_service.py --n-total 256 --n-samples 200 --n-dsp 256
 
 This script tests that the Attribution Reporting API (ARAPI, previously known as Conversion Measurement API or CMAPI) works. It does so by visiting an ARAPI-enabled ad, clicking on it and taking a screenshot of the browser's conversion internals.
 
-#### _arapi_conversion_
+#### _arapi_events_
 
-This script tests ARAPI conversions. It does so by visiting an ARAPI-enabled ad, clicking on it and and then going forward with two actions: _add-to-cart_ and _checkout_. Finally, it forces the browser to send the reports to the DSP, which are then saved under _output/arapi_reports_dir_. It provides with a simple minimal example of ARAPI usage. For now, it only supports event-level reporting.
+This script tests ARAPI events. It does so by visiting an ARAPI-enabled ad, clicking on it and and then going forward with two actions: _add-to-cart_ and _checkout_. Finally, it forces the browser to send the reports to the DSP, which are then saved under _output/arapi_reports_dir_. It provides with a simple minimal example of ARAPI usage. For now, it only supports event-level reporting.
 
 TODO: add aggregate-level reporting (must check first if it is available)
 
@@ -242,7 +242,8 @@ You can learn more by looking at the [relevant section](https://github.com/WICG/
 
 ## TODOs
 
-- Reintroduce WASM (removed for convenience when incorporating M1 architecture compatibility)
+- Experiment with the daily update URL.
+- Reintroduce/fix WASM (removed for convenience when incorporating M1 architecture compatibility).
 - Add assertions to the scripts to make sure we do not miss any failures.
 - Explore [reporting](https://github.com/WICG/turtledove/blob/main/FLEDGE.md#5-event-level-reporting-for-now).
 

--- a/advertiser/public/ads/dynamic-attribution-reporting-ad.html
+++ b/advertiser/public/ads/dynamic-attribution-reporting-ad.html
@@ -12,9 +12,6 @@
   </body>
 </html>
 
-<!-- attributionsourceeventid is a 64 bit unsigned integer, represented as a string -->
-<!-- attributionexpiry is in milliseconds and must be between 2 and 30 days -->
-
 <script>
   // dynamic ad created to ease tests. The name of the IG will be shown on the page.
   const urlParams = new URLSearchParams(window.location.search);
@@ -24,22 +21,10 @@
     urlParams.get("href") == null
       ? "https://advertiser"
       : urlParams.get("href");
-  const attributiondestination =
-    urlParams.get("attributiondestination") == null
-      ? "https://advertiser"
-      : urlParams.get("attributiondestination");
-  const attributionreportto =
-    urlParams.get("attributionreportto") == null
-      ? "https://dsp"
-      : urlParams.get("attributionreportto");
-  const attributionsourceeventid =
-    urlParams.get("attributionsourceeventid") == null
-      ? "1010"
-      : urlParams.get("attributionsourceeventid");
-  const attributionexpiry =
-    urlParams.get("attributionexpiry") == null
-      ? "864000000"
-      : urlParams.get("attributionexpiry");
+  const attributionsrc =
+    urlParams.get("attributionsrc") == null
+      ? "https://dsp/register-source"
+      : urlParams.get("attributionsrc");
 
   document.addEventListener("DOMContentLoaded", function () {
     document.getElementById("text").innerText = text;
@@ -48,10 +33,7 @@
 
     ad.innerText = text;
     ad.setAttribute("href", href);
-    ad.setAttribute("attributiondestination", attributiondestination);
-    ad.setAttribute("attributionreportto", attributionreportto);
-    ad.setAttribute("attributionsourceeventid", attributionsourceeventid);
-    ad.setAttribute("attributionexpiry", attributionexpiry);
+    ad.setAttribute("attributionsrc", attributionsrc);
 
     // this seems like a hacky workaround given that ARAPI has this dynamic
     // way of doing things with window.open but I was losing too much time

--- a/client/experiments.sh
+++ b/client/experiments.sh
@@ -26,7 +26,7 @@ python test_interest_group_amount.py --n-IGs 10 --n-samples-before-maintenance 3
 python denial_of_service.py --n-total 10 --n-samples 8 --n-dsp 1
 
 python arapi_click.py
-python arapi_conversion.py
+python arapi_events.py
 
 date
 echo "Done."

--- a/client/scripts/arapi_click.py
+++ b/client/scripts/arapi_click.py
@@ -12,7 +12,7 @@ logging.basicConfig(filename=os.path.join(output_path, 'log'), filemode='w',
 browser = utils.get_browser()
 
 
-browser.get('chrome://conversion-internals/')
+browser.get('chrome://attribution-internals/')
 logging.info('dashboard before click')
 time.sleep(3)
 browser.save_screenshot(os.path.join(output_path, 'dashboard_before_click.png'))
@@ -28,7 +28,7 @@ logging.info('clicked on ad')
 time.sleep(1)
 browser.save_screenshot(os.path.join(output_path, 'after_click.png'))
 
-browser.get('chrome://conversion-internals/')
+browser.get('chrome://attribution-internals/')
 logging.info('dashboard after click')
 time.sleep(3)
 browser.save_screenshot(os.path.join(output_path, 'dashboard_after_click.png'))

--- a/client/scripts/arapi_events.py
+++ b/client/scripts/arapi_events.py
@@ -12,7 +12,7 @@ logging.basicConfig(filename=os.path.join(output_path, 'log'), filemode='w',
 browser = utils.get_browser()
 
 
-browser.get('chrome://conversion-internals/')
+browser.get('chrome://attribution-internals/')
 logging.info('dashboard before click')
 time.sleep(3)
 browser.save_screenshot(os.path.join(output_path, 'dashboard_before_click.png'))
@@ -36,17 +36,21 @@ browser.get('https://advertiser/arapi-event?type=checkout')
 logging.info('checkout')
 time.sleep(1)
 
-browser.get('chrome://conversion-internals/')
+browser.get('chrome://attribution-internals/')
 logging.info('dashboard after events')
 time.sleep(3)
-browser.save_screenshot(os.path.join(output_path, 'dashboard_after_events.png'))
+browser.save_screenshot(os.path.join(output_path, 'dashboard_sources_after_events.png'))
+
+# switch to the event-level reports tag
+browser.find_element(By.XPATH, "//tab[text()='Event-Level Reports']").click()
+time.sleep(2)
+browser.save_screenshot(os.path.join(output_path, 'dashboard_event_level_reports_after_events.png'))
 
 # we force the browser to send the reports instead of waiting for the scheduled time
-checkboxes = browser.find_element(By.XPATH, "//input[@type='checkbox']")
-checkboxes.click()
-send_reports_button = browser.find_element(By.ID, 'send-reports')
-send_reports_button.click()
+browser.find_element(By.XPATH, "//thead/tr/th/input[@type='checkbox']").click()
 time.sleep(1)
+send_reports_button = browser.find_element(By.ID, 'send-reports').click()
+time.sleep(2)
 
 browser.quit()
 print(f"Done: {__file__}")

--- a/client/scripts/utils.py
+++ b/client/scripts/utils.py
@@ -20,8 +20,7 @@ def get_browser(extra_args: List[str] = []):
         webdriver.Chrome: Chromium instance controlled with the Selenium driver.
     """
     chrome_args_unwrapped = os.environ['CHROME_ARGS'].split(' ')
-    arapi_flags_unwrapped = os.environ['ARAPI_FLAGS'].split(' ')
-    args = chrome_args_unwrapped + [os.environ['FLEDGE_FLAGS']] + arapi_flags_unwrapped + extra_args
+    args = chrome_args_unwrapped + [os.environ['PRIVACY_SANDBOX_FLAGS']] + extra_args
     options = webdriver.ChromeOptions()
     for arg in args:
         options.add_argument(arg)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,7 +65,8 @@ services:
     build:
       context: client/
       args:
-        - CHROMIUM_REVISION=961137  # 99.0.4841.0 2022-01-19
+        # - CHROMIUM_REVISION=993199  # Chromium 103.0.5009.0 2022-04-17, fenced frame is displayed correctly but ad no longer renders... TODO: fix/find out why
+        - CHROMIUM_REVISION=992118  # 102.0.5003.0 2022-04-13
     depends_on:
       - advertiser
       - dsp
@@ -75,8 +76,8 @@ services:
       - "127.0.0.1:5920:5920" # for VNC access
     environment:
       - CHROME_ARGS=--no-sandbox --disable-gpu --no-first-run --disable-sync --disable-dev-shm-usage
-      - FLEDGE_FLAGS=--enable-features=InterestGroupStorage,AdInterestGroupAPI,Fledge,FencedFrames
-      - ARAPI_FLAGS=--flag-switches-begin --enable-experimental-web-platform-features --flag-switches-end
+      # see: https://chromium-review.googlesource.com/c/chromium/src/+/3558276/6/chrome/browser/about_flags.cc#7134
+      - PRIVACY_SANDBOX_FLAGS=--enable-features=FencedFrames,PrivacySandboxAdsAPIsOverride,InterestGroupStorage,Fledge,AllowURNsInIframes,BrowsingTopics,ConversionMeasurement,OverridePrivacySandboxSettingsLocalTesting
     volumes:
       - ./output:/opt/output
       - ./client/scripts:/opt/scripts

--- a/dsp/Dockerfile
+++ b/dsp/Dockerfile
@@ -16,7 +16,7 @@ ENV CAROOT=/opt
 RUN mkcert -install
 
 # Install npm dependencies
-RUN npm install express
+RUN npm install express@4.18.0
 
 ##### Rust portion for WASM
 # TODO: add multi-stage build? Image size is not a concern for this at the moment though


### PR DESCRIPTION
This PR upgrades chromium from version 99 to 102. This required a few adjustments, particularly to ARAPI given its recent API changes.