### PR TITLE
Add fledge click report with arapi

### DIFF
--- a/advertiser/public/ads/dynamic-attribution-reporting-with-click-ad.html
+++ b/advertiser/public/ads/dynamic-attribution-reporting-with-click-ad.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <link rel="icon" href="data:," />
+    <!-- suppress favicon fetch -->
+  </head>
+
+  <body>
+    <a id="ad">
+      <h3>Dynamic Ad: <span id="text"></span></h3>
+    </a>
+  </body>
+</html>
+
+<!-- attributionsourceeventid is a 64 bit unsigned integer, represented as a string -->
+<!-- attributionexpiry is in milliseconds and must be between 2 and 30 days -->
+
+<script>
+  // dynamic ad created to ease tests. The name of the IG will be shown on the page.
+  const urlParams = new URLSearchParams(window.location.search);
+  const text =
+    urlParams.get("text") == null ? "placeholder" : urlParams.get("text");
+  const href =
+    urlParams.get("href") == null
+      ? "https://advertiser"
+      : urlParams.get("href");
+  const attributiondestination =
+    urlParams.get("attributiondestination") == null
+      ? "https://advertiser"
+      : urlParams.get("attributiondestination");
+  const attributionreportto =
+    urlParams.get("attributionreportto") == null
+      ? "https://dsp"
+      : urlParams.get("attributionreportto");
+  const attributionsourceeventid =
+    urlParams.get("attributionsourceeventid") == null
+      ? "1010"
+      : urlParams.get("attributionsourceeventid");
+  const attributionexpiry =
+    urlParams.get("attributionexpiry") == null
+      ? "864000000"
+      : urlParams.get("attributionexpiry");
+
+  document.addEventListener("DOMContentLoaded", function () {
+    document.getElementById("text").innerText = text;
+
+    const ad = document.getElementById("ad");
+
+    ad.innerText = text;
+    ad.setAttribute("href", href);
+    ad.setAttribute("attributiondestination", attributiondestination);
+    ad.setAttribute("attributionreportto", attributionreportto);
+    ad.setAttribute("attributionsourceeventid", attributionsourceeventid);
+    ad.setAttribute("attributionexpiry", attributionexpiry);
+
+    // this seems like a hacky workaround given that ARAPI has this dynamic
+    // way of doing things with window.open but I was losing too much time
+    // trying to get it to work so I ended up doing this instead
+    // See: https://developer.chrome.com/docs/privacy-sandbox/attribution-reporting-event-guide/#register-clicks-with-windowopen
+
+  });
+
+  //configure fenced frame report
+  const ad = document.getElementById("ad");
+
+  ad.addEventListener("click", function() {
+    window.fence.reportEvent({
+        'eventType': 'click',
+        'eventData': attributionsourceeventid,
+        'destination': ['buyer']
+    });
+
+  })
+
+</script>

--- a/advertiser/public/index.html
+++ b/advertiser/public/index.html
@@ -12,6 +12,7 @@
     <ul>
       <li><a href="/shoe-a">Shoe A</a></li>
       <li><a href="/shoe-b">Shoe B</a></li>
+      <li><a href="/shoe-c">Shoe B</a></li>
     </ul>
 
     We just joined an IG that will bid 1 to show a "Come see all shoes" ad.

--- a/advertiser/public/index.html
+++ b/advertiser/public/index.html
@@ -12,7 +12,7 @@
     <ul>
       <li><a href="/shoe-a">Shoe A</a></li>
       <li><a href="/shoe-b">Shoe B</a></li>
-      <li><a href="/shoe-c">Shoe B</a></li>
+      <li><a href="/shoe-c">Shoe C</a></li>
     </ul>
 
     We just joined an IG that will bid 1 to show a "Come see all shoes" ad.

--- a/advertiser/public/shoe-c.html
+++ b/advertiser/public/shoe-c.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" href="data:," />
+    <title>Advertiser</title>
+  </head>
+
+  <body>
+    <h1>The Shoe Store - Shoe C</h1>
+
+    We just joined an IG that will bid 5 to show shoe C's ad that uses ARAPI.
+
+    <iframe
+      width="1"
+      height="1"
+      src="https://dsp/arapi-ad-interest-group"
+      style="border: none"
+    ></iframe>
+  </body>
+</html>

--- a/dsp/public/arapi-ad-interest-group.html
+++ b/dsp/public/arapi-ad-interest-group.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>DSP</title>
+  </head>
+
+  <body></body>
+</html>
+
+<script>
+  const generalAdGroup = {
+    owner: "https://dsp",
+    name: "arapi-ad-ig",
+    biddingLogicUrl: "https://dsp/bidding_logic.js",
+    trustedBiddingSignalsUrl: "https://dsp/bidding_signal.json",
+    trustedBiddingSignalsKeys: ["key1", "key2"],
+    dailyUpdateUrl: "https://dsp/daily_update_url",
+    userBiddingSignals: {
+      user_bidding_signals: "user_bidding_signals",
+      bid: 5
+    },
+    ads: [
+      {
+        renderUrl: "https://advertiser/ads/dynamic-attribution-reporting-with-click-ad",
+      },
+    ],
+  };
+
+  document.addEventListener("DOMContentLoaded", async (e) => {
+    console.log(e);
+    const kSecsPerDay = 3600 * 24 * 30;
+    console.log(
+      await navigator.joinAdInterestGroup(generalAdGroup, kSecsPerDay)
+    );
+  });
+</script>

--- a/dsp/public/bidding_logic.js
+++ b/dsp/public/bidding_logic.js
@@ -41,4 +41,10 @@ function reportWin(
     browserSignals,
   });
   sendReportTo(browserSignals.interestGroupOwner + "/reporting?report=win");
+
+  // NB: the buyer_event_id should really come from perBuyerSignals, that way DSP will have this
+  // value on its server. This will allow us to link imp->click->conversion (see dynamic-attribution-reporting-with-click-ad.html)
+  registerAdBeacon({
+    'click': "https://dsp/click_reports?buyer_event_id=123",
+   });
 }

--- a/dsp/server.js
+++ b/dsp/server.js
@@ -8,6 +8,7 @@ const port = process.env.PORT;
 const key = process.env.KEY;
 const cert = process.env.CERT;
 const ARAPI_REPORTS_REPO = '/opt/output/arapi_reports_repo';
+const FLEDGE_REPORTS_REPO = '/opt/output/click_reports_repo';
 
 const arapiEvents = {
   "add-to-cart": 0,
@@ -66,6 +67,28 @@ app.post(
     let reportFilename = `/opt/output/arapi_reports_repo/${arapiReportCounter++}.json`;
     if (!fs.existsSync(ARAPI_REPORTS_REPO)) {
       fs.mkdirSync(ARAPI_REPORTS_REPO, { recursive: true });
+    }
+    fs.writeFile(reportFilename, JSON.stringify(req.body), (err) => {
+      if (err) {
+        console.error(err);
+        return;
+      }
+    });
+  }
+);
+
+// fledge click report
+// NB: this currenly creates an empty file, it does not seem to write the actual request body.
+// I tried playing around with it but had no luck. I see in the browser console that eventData is
+// including in the request payload. That was good enough for me to confirm that we can send
+// the ARAPI attribution source event ID through the fledge click report.  
+app.post(
+  "/click_reports",
+  (req, res) => {
+    const buyer_event_id = req.query.buyer_event_id;
+    let reportFilename = `/opt/output/click_reports_repo/${buyer_event_id}.json`;
+    if (!fs.existsSync(FLEDGE_REPORTS_REPO)) {
+      fs.mkdirSync(FLEDGE_REPORTS_REPO, { recursive: true });
     }
     fs.writeFile(reportFilename, JSON.stringify(req.body), (err) => {
       if (err) {


### PR DESCRIPTION
This PR adds an example of how a DSP can use ARAPI and fledge event level reporting to label each click with whether it lead to a conversion or not. 

This implements the idea discussed here: https://github.com/WICG/turtledove/issues/281